### PR TITLE
Raise maximum image size in ImgScalrFileChooser

### DIFF
--- a/ui-contrib/src/main/java/com/kotcrab/vis/ui/contrib/widget/file/ImgScalrFileChooserIconProvider.java
+++ b/ui-contrib/src/main/java/com/kotcrab/vis/ui/contrib/widget/file/ImgScalrFileChooserIconProvider.java
@@ -51,8 +51,8 @@ import java.io.InputStream;
  */
 public class ImgScalrFileChooserIconProvider extends CachingFileChooserIconProvider {
 	private static final Color tmpColor = new Color();
-	private static final int MAX_IMAGE_WIDTH = 4096;
-	private static final int MAX_IMAGE_HEIGHT = 4096;
+	private static final int MAX_IMAGE_WIDTH = 8192;
+	private static final int MAX_IMAGE_HEIGHT = 8192;
 
 	public ImgScalrFileChooserIconProvider (FileChooser chooser) {
 		super(chooser);


### PR DESCRIPTION
A size of 4096 is to small that most current digital cameras produce larger images. For example the images I want to work with are all 6000x4000 pixels, it's accepted that resizing these will be slow.

If simply raising the constants isn't acceptable, then I could present a PR that allows the user to specify maximum dimensions at runtime (which while probably being the better long term solution wasn't as easy as just raising the constants :) )